### PR TITLE
Fix dot size for calendar

### DIFF
--- a/src/components/Events/Calendar/Calendar.js
+++ b/src/components/Events/Calendar/Calendar.js
@@ -82,9 +82,10 @@ class Calendar extends Component {
                       'fa-layers-text ' + (sameDay ? 'text-white' : '')
                     }
                     transform="bottom-100"
-                    style={{ marginTop: '.6em' }}
                   >
-                    <h4>{day.format('D')}</h4>
+                    <h6>
+                      <b>{day.format('D')}</b>
+                    </h6>
                   </span>
                 </span>
               </Col>


### PR DESCRIPTION
This closes #38. Now the calendar looks like this locally, which looks pretty much the same as what's on nususc.com:

![Screenshot from 2019-09-02 23-15-12](https://user-images.githubusercontent.com/41856541/64123714-bcc1f000-cdd7-11e9-8991-965b0c1890c8.png)
