### PR TITLE
Use href prop to navigate links vs onClick

### DIFF
--- a/src/components/General/Navbar.js
+++ b/src/components/General/Navbar.js
@@ -163,17 +163,7 @@ class SiteNavbar extends Component {
     _.forEach(this.navbarItems, item => {
       items.push(
         <NavItem key={item.link}>
-          <NavLink
-            style={{ cursor: 'pointer' }}
-            onClick={() => {
-              if (isOpen) {
-                this.toggle()
-              }
-              history.push(item.link)
-            }}
-          >
-            {item.display}
-          </NavLink>
+          <NavLink href={item.link}>{item.display}</NavLink>
         </NavItem>
       )
     })


### PR DESCRIPTION
Using the href prop automatically gives it the cursor pointer style as
well, so we don't need to style it manually.

Looking at reactstrap docs, I believe this is a more idiomatic use of the component. The user also gets a hint of where they are navigating
![image](https://user-images.githubusercontent.com/22059033/66054941-4aeadc80-e524-11e9-9b99-aec2a204d032.png)