### PR TITLE
Remove CTPH option from EventForm

### DIFF
--- a/src/components/Events/EventForm.js
+++ b/src/components/Events/EventForm.js
@@ -80,10 +80,12 @@ class EventForm extends Component {
 
     if (spaces.isLoaded) {
       _.forEach(spaces.ordered, space => {
-        options.push({
-          id: space.id,
-          display: space.name
-        })
+        if (space.name != 'CTPH-Old' && space.name != 'CTPH') {
+          options.push({
+            id: space.id,
+            display: space.name
+          })
+        }
       })
     }
 

--- a/src/components/Events/EventForm.js
+++ b/src/components/Events/EventForm.js
@@ -80,7 +80,7 @@ class EventForm extends Component {
 
     if (spaces.isLoaded) {
       _.forEach(spaces.ordered, space => {
-        if (space.name != 'CTPH-Old' && space.name != 'CTPH') {
+        if (space.name !== 'CTPH-Old' && space.name !== 'CTPH') {
           options.push({
             id: space.id,
             display: space.name


### PR DESCRIPTION
As per a USC request. This should remove the option of making CTPH bookings from here on out. Previous bookings under CTPH are still valid. This may be expanded to give admin rights to book CTPH in future, for USP admin to use.

Bucket before backup: `gs://usc-website-206715.appspot.com/2019-12-04T12:09:28_94001`

Before:
![image](https://user-images.githubusercontent.com/19257264/70143668-3ae3aa80-16d7-11ea-893d-879ea79d73a0.png)
