### PR TITLE
Fix datepicker

### DIFF
--- a/src/components/reusable/FormInputs.js
+++ b/src/components/reusable/FormInputs.js
@@ -234,7 +234,7 @@ export const DatePickerInput = asField(({ fieldState, fieldApi, ...props }) => {
         }
         showTimeSelect={!props.dateOnly}
         timeFormat="hh:mm a"
-        timeInterval={config.timeInterval}
+        timeIntervals={config.timeInterval}
         dateFormat="LLL"
         timeCaption="time"
       />

--- a/src/resources/react-datepicker.css
+++ b/src/resources/react-datepicker.css
@@ -1,10 +1,12 @@
+/* Taken from dist/react-datepicker.css of react-datepicker v3.1.3 */
+/* Not using the css file bundled with the version we are using (v1.8.0) due to a slight issue with the time picker being too narrow + misaligned */
+
 .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle, .react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle, .react-datepicker__year-read-view--down-arrow,
 .react-datepicker__month-read-view--down-arrow,
 .react-datepicker__month-year-read-view--down-arrow {
   margin-left: -8px;
   position: absolute;
 }
-
 
 .react-datepicker-popper[data-placement^="bottom"] .react-datepicker__triangle, .react-datepicker-popper[data-placement^="top"] .react-datepicker__triangle, .react-datepicker__year-read-view--down-arrow,
 .react-datepicker__month-read-view--down-arrow,
@@ -68,6 +70,8 @@
 
 .react-datepicker-wrapper {
   display: inline-block;
+  padding: 0;
+  border: 0;
 }
 
 .react-datepicker {
@@ -108,6 +112,11 @@
 
 .react-datepicker-popper[data-placement^="bottom"] {
   margin-top: 10px;
+}
+
+.react-datepicker-popper[data-placement="bottom-end"] .react-datepicker__triangle, .react-datepicker-popper[data-placement="top-end"] .react-datepicker__triangle {
+  left: auto;
+  right: 50px;
 }
 
 .react-datepicker-popper[data-placement^="top"] {
@@ -159,7 +168,8 @@
 }
 
 .react-datepicker__current-month,
-.react-datepicker-time__header {
+.react-datepicker-time__header,
+.react-datepicker-year-header {
   margin-top: 0;
   color: #000;
   font-weight: bold;
@@ -183,6 +193,10 @@
   padding: 0;
   border: 0.45rem solid transparent;
   z-index: 1;
+  height: 10px;
+  width: 10px;
+  text-indent: -999em;
+  overflow: hidden;
 }
 
 .react-datepicker__navigation--previous {
@@ -247,15 +261,79 @@
   float: left;
 }
 
+.react-datepicker__year {
+  margin: 0.4rem;
+  text-align: center;
+}
+
+.react-datepicker__year-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 180px;
+}
+
+.react-datepicker__year .react-datepicker__year-text {
+  display: inline-block;
+  width: 4rem;
+  margin: 2px;
+}
+
 .react-datepicker__month {
   margin: 0.4rem;
   text-align: center;
 }
 
+.react-datepicker__month .react-datepicker__month-text,
+.react-datepicker__month .react-datepicker__quarter-text {
+  display: inline-block;
+  width: 4rem;
+  margin: 2px;
+}
+
+.react-datepicker__input-time-container {
+  clear: both;
+  width: 100%;
+  float: left;
+  margin: 5px 0 10px 15px;
+  text-align: left;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__caption {
+  display: inline-block;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container {
+  display: inline-block;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input {
+  display: inline-block;
+  margin-left: 10px;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input {
+  width: 85px;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"]::-webkit-inner-spin-button,
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__input input[type="time"] {
+  -moz-appearance: textfield;
+}
+
+.react-datepicker__input-time-container .react-datepicker-time__input-container .react-datepicker-time__delimiter {
+  margin-left: 5px;
+  display: inline-block;
+}
+
 .react-datepicker__time-container {
   float: right;
   border-left: 1px solid #aeaeae;
-  width: 70px;
+  width: 85px;
 }
 
 .react-datepicker__time-container--with-today-button {
@@ -270,10 +348,11 @@
 .react-datepicker__time-container .react-datepicker__time {
   position: relative;
   background: white;
+  border-bottom-right-radius: 0.3rem;
 }
 
 .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box {
-  width: 70px;
+  width: 85px;
   overflow-x: hidden;
   margin: 0 auto;
   text-align: center;
@@ -284,13 +363,16 @@
   margin: 0;
   height: calc(195px + (1.7rem / 2));
   overflow-y: scroll;
-  padding-right: 30px;
+  padding-right: 0px;
+  padding-left: 0px;
   width: 100%;
   box-sizing: content-box;
 }
 
 .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item {
+  height: 30px;
   padding: 5px 10px;
+  white-space: nowrap;
 }
 
 .react-datepicker__time-container .react-datepicker__time .react-datepicker__time-box ul.react-datepicker__time-list li.react-datepicker__time-list-item:hover {
@@ -351,78 +433,177 @@
   margin: 0.166rem;
 }
 
-.react-datepicker__day {
-  cursor: pointer;
-}
-
-.react-datepicker__day:hover {
-  border-radius: 0.3rem;
-  background-color: #f0f0f0;
-}
-
-.react-datepicker__day--today {
-  font-weight: bold;
-}
-
-.react-datepicker__day--highlighted {
-  border-radius: 0.3rem;
-  background-color: #3dcc4a;
-  color: #fff;
-}
-
-.react-datepicker__day--highlighted:hover {
-  background-color: #32be3f;
-}
-
-.react-datepicker__day--highlighted-custom-1 {
-  color: magenta;
-}
-
-.react-datepicker__day--highlighted-custom-2 {
-  color: green;
-}
-
-.react-datepicker__day--selected, .react-datepicker__day--in-selecting-range, .react-datepicker__day--in-range {
+.react-datepicker__month--selected, .react-datepicker__month--in-selecting-range, .react-datepicker__month--in-range,
+.react-datepicker__quarter--selected,
+.react-datepicker__quarter--in-selecting-range,
+.react-datepicker__quarter--in-range {
   border-radius: 0.3rem;
   background-color: #216ba5;
   color: #fff;
 }
 
-.react-datepicker__day--selected:hover, .react-datepicker__day--in-selecting-range:hover, .react-datepicker__day--in-range:hover {
+.react-datepicker__month--selected:hover, .react-datepicker__month--in-selecting-range:hover, .react-datepicker__month--in-range:hover,
+.react-datepicker__quarter--selected:hover,
+.react-datepicker__quarter--in-selecting-range:hover,
+.react-datepicker__quarter--in-range:hover {
   background-color: #1d5d90;
 }
 
-.react-datepicker__day--keyboard-selected {
+.react-datepicker__month--disabled,
+.react-datepicker__quarter--disabled {
+  color: #ccc;
+  pointer-events: none;
+}
+
+.react-datepicker__month--disabled:hover,
+.react-datepicker__quarter--disabled:hover {
+  cursor: default;
+  background-color: transparent;
+}
+
+.react-datepicker__day,
+.react-datepicker__month-text,
+.react-datepicker__quarter-text,
+.react-datepicker__year-text {
+  cursor: pointer;
+}
+
+.react-datepicker__day:hover,
+.react-datepicker__month-text:hover,
+.react-datepicker__quarter-text:hover,
+.react-datepicker__year-text:hover {
+  border-radius: 0.3rem;
+  background-color: #f0f0f0;
+}
+
+.react-datepicker__day--today,
+.react-datepicker__month-text--today,
+.react-datepicker__quarter-text--today,
+.react-datepicker__year-text--today {
+  font-weight: bold;
+}
+
+.react-datepicker__day--highlighted,
+.react-datepicker__month-text--highlighted,
+.react-datepicker__quarter-text--highlighted,
+.react-datepicker__year-text--highlighted {
+  border-radius: 0.3rem;
+  background-color: #3dcc4a;
+  color: #fff;
+}
+
+.react-datepicker__day--highlighted:hover,
+.react-datepicker__month-text--highlighted:hover,
+.react-datepicker__quarter-text--highlighted:hover,
+.react-datepicker__year-text--highlighted:hover {
+  background-color: #32be3f;
+}
+
+.react-datepicker__day--highlighted-custom-1,
+.react-datepicker__month-text--highlighted-custom-1,
+.react-datepicker__quarter-text--highlighted-custom-1,
+.react-datepicker__year-text--highlighted-custom-1 {
+  color: magenta;
+}
+
+.react-datepicker__day--highlighted-custom-2,
+.react-datepicker__month-text--highlighted-custom-2,
+.react-datepicker__quarter-text--highlighted-custom-2,
+.react-datepicker__year-text--highlighted-custom-2 {
+  color: green;
+}
+
+.react-datepicker__day--selected, .react-datepicker__day--in-selecting-range, .react-datepicker__day--in-range,
+.react-datepicker__month-text--selected,
+.react-datepicker__month-text--in-selecting-range,
+.react-datepicker__month-text--in-range,
+.react-datepicker__quarter-text--selected,
+.react-datepicker__quarter-text--in-selecting-range,
+.react-datepicker__quarter-text--in-range,
+.react-datepicker__year-text--selected,
+.react-datepicker__year-text--in-selecting-range,
+.react-datepicker__year-text--in-range {
+  border-radius: 0.3rem;
+  background-color: #216ba5;
+  color: #fff;
+}
+
+.react-datepicker__day--selected:hover, .react-datepicker__day--in-selecting-range:hover, .react-datepicker__day--in-range:hover,
+.react-datepicker__month-text--selected:hover,
+.react-datepicker__month-text--in-selecting-range:hover,
+.react-datepicker__month-text--in-range:hover,
+.react-datepicker__quarter-text--selected:hover,
+.react-datepicker__quarter-text--in-selecting-range:hover,
+.react-datepicker__quarter-text--in-range:hover,
+.react-datepicker__year-text--selected:hover,
+.react-datepicker__year-text--in-selecting-range:hover,
+.react-datepicker__year-text--in-range:hover {
+  background-color: #1d5d90;
+}
+
+.react-datepicker__day--keyboard-selected,
+.react-datepicker__month-text--keyboard-selected,
+.react-datepicker__quarter-text--keyboard-selected,
+.react-datepicker__year-text--keyboard-selected {
   border-radius: 0.3rem;
   background-color: #2a87d0;
   color: #fff;
 }
 
-.react-datepicker__day--keyboard-selected:hover {
+.react-datepicker__day--keyboard-selected:hover,
+.react-datepicker__month-text--keyboard-selected:hover,
+.react-datepicker__quarter-text--keyboard-selected:hover,
+.react-datepicker__year-text--keyboard-selected:hover {
   background-color: #1d5d90;
 }
 
-.react-datepicker__day--in-selecting-range:not(.react-datepicker__day--in-range) {
+.react-datepicker__day--in-selecting-range ,
+.react-datepicker__month-text--in-selecting-range ,
+.react-datepicker__quarter-text--in-selecting-range ,
+.react-datepicker__year-text--in-selecting-range {
   background-color: rgba(33, 107, 165, 0.5);
 }
 
-.react-datepicker__month--selecting-range .react-datepicker__day--in-range:not(.react-datepicker__day--in-selecting-range) {
+.react-datepicker__month--selecting-range .react-datepicker__day--in-range , .react-datepicker__month--selecting-range
+.react-datepicker__month-text--in-range , .react-datepicker__month--selecting-range
+.react-datepicker__quarter-text--in-range , .react-datepicker__month--selecting-range
+.react-datepicker__year-text--in-range {
   background-color: #f0f0f0;
   color: #000;
 }
 
-.react-datepicker__day--disabled {
+.react-datepicker__day--disabled,
+.react-datepicker__month-text--disabled,
+.react-datepicker__quarter-text--disabled,
+.react-datepicker__year-text--disabled {
   cursor: default;
   color: #ccc;
 }
 
-.react-datepicker__day--disabled:hover {
+.react-datepicker__day--disabled:hover,
+.react-datepicker__month-text--disabled:hover,
+.react-datepicker__quarter-text--disabled:hover,
+.react-datepicker__year-text--disabled:hover {
   background-color: transparent;
+}
+
+.react-datepicker__month-text.react-datepicker__month--selected:hover, .react-datepicker__month-text.react-datepicker__month--in-range:hover, .react-datepicker__month-text.react-datepicker__quarter--selected:hover, .react-datepicker__month-text.react-datepicker__quarter--in-range:hover,
+.react-datepicker__quarter-text.react-datepicker__month--selected:hover,
+.react-datepicker__quarter-text.react-datepicker__month--in-range:hover,
+.react-datepicker__quarter-text.react-datepicker__quarter--selected:hover,
+.react-datepicker__quarter-text.react-datepicker__quarter--in-range:hover {
+  background-color: #216ba5;
+}
+
+.react-datepicker__month-text:hover,
+.react-datepicker__quarter-text:hover {
+  background-color: #f0f0f0;
 }
 
 .react-datepicker__input-container {
   position: relative;
   display: inline-block;
+  width: 100%;
 }
 
 .react-datepicker__year-read-view,
@@ -539,34 +720,33 @@
 }
 
 .react-datepicker__close-icon {
+  cursor: pointer;
   background-color: transparent;
   border: 0;
-  cursor: pointer;
-  display: inline-block;
-  height: 0;
   outline: 0;
-  padding: 0;
+  padding: 0px 6px 0px 0px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  display: table-cell;
   vertical-align: middle;
 }
 
 .react-datepicker__close-icon::after {
-  background-color: #216ba5;
-  border-radius: 50%;
-  bottom: 0;
-  box-sizing: border-box;
-  color: #fff;
-  content: "\00d7";
   cursor: pointer;
-  font-size: 12px;
+  background-color: #216ba5;
+  color: #fff;
+  border-radius: 50%;
   height: 16px;
   width: 16px;
-  line-height: 1;
-  margin: -8px auto 0;
   padding: 2px;
-  position: absolute;
-  right: 7px;
+  font-size: 12px;
+  line-height: 1;
   text-align: center;
-  top: 50%;
+  display: table-cell;
+  vertical-align: middle;
+  content: "\00d7";
 }
 
 .react-datepicker__today-button {
@@ -641,8 +821,4 @@
 .react-datepicker__portal .react-datepicker__navigation--next--disabled, .react-datepicker__portal .react-datepicker__navigation--next--disabled:hover {
   border-left-color: #e6e6e6;
   cursor: default;
-}
-
-ul.react-datepicker__time-list {
-    padding: 0;
 }


### PR DESCRIPTION
# Pull Request (PR) - Fix datepicker
## Description of Change
- Turns out the ugly datepicker was caused by the CSS, fixed it by borrowing the CSS from the latest version of the library
- Also fixed a typo in one of the props being passed to the datepicker (`timeIntervals`) - it hasn't been caught yet because we happen to be using the same as the default value

## Link To Issue 
Fixes #145 

## How to test this change
Tested using the /createevent page on localhost in Firefox and Chrome:

![2020-08-08-162727_511x414_scrot](https://user-images.githubusercontent.com/43085850/89706254-72a59f00-d996-11ea-85a5-1396927d0f14.png)

I've also checked that the logic to check the validity of the dates (start and end date, within 2 hours) still works as before

## Checklists
### Checklist for developer of feature
- [X] I have performed a code review on my own code
- [ ] I have written unit tests to test my code
- [ ] All Unit Tests pass when ran
- [X] I have linked to the appropriate issue on GitHub
- [X] I have written an appropriate description for this PR.
- [X] I have written how to test this PR.

### Checklist for reviewers
- [ ] I have reviewed the new code
- [ ] I have checked that new unit tests have been written
- [ ] I have ran the unit tests and they pass.
- [ ] I have followed the given steps to test the PR


