### PR TITLE
Updated Google Calendar Scope in line with new OAuth requirements

### DIFF
--- a/src/resources/config.js
+++ b/src/resources/config.js
@@ -34,7 +34,7 @@ export const firebaseConfig = {
   messagingSenderId: '115895791273',
   clientId:
     '115895791273-6hbrflf3p4hq9o9b1td3lijq602eb3jk.apps.googleusercontent.com',
-  scopes: ['email', 'profile', 'https://www.googleapis.com/auth/calendar'],
+  scopes: ['email', 'profile', 'https://www.googleapis.com/auth/calendar.app.created'],
   discoveryDocs: [
     'https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'
   ]


### PR DESCRIPTION
## Description of Change
I edited the scopes requested by Firebase Auth so that it doesn't request for a restricted scope. It's what has been causing errors for people attempting to login.

## Link To Issue 
I don't think any proper error was filed on Github for this. 

## How to test this change
That anyone can now login without receiving an error.

## Checklists
### Checklist for developer of feature
- [X ] I have performed a code review on my own code
- [ X] I have tested my code against the Travis CI, and it has passed.
- [ X] I have linked to the appropriate issue on GitHub
- [ X] I have written an appropriate description for this PR.
- [ X] I have written how to test this PR.

### Checklist for reviewers
- [x] I have reviewed the new code
- [x] I have followed the given steps to test the PR, and it passes.